### PR TITLE
Borrow allow fixes

### DIFF
--- a/src/components/dialog/borrow/BorrowInput.vue
+++ b/src/components/dialog/borrow/BorrowInput.vue
@@ -187,8 +187,6 @@ export default {
   },
   methods: {
     async borrowAllowed() {
-      //TODO get de ammount in cToken values
-      return "";
       return this.data.market
         .borrowAllowed(this.amount, this.account)
         .then((allowed) => {

--- a/src/components/dialog/borrow/BorrowInput.vue
+++ b/src/components/dialog/borrow/BorrowInput.vue
@@ -324,6 +324,19 @@ export default {
           // this.borrowLimitInfo = Number(this //TODO enable this
           //   .getMaxBorrowAllowed(this.oldLiquidity, this.oldCash) - this.maxBorrowAllowed);
         });
+          // Toggle this block to test getValues update on borrowAllowed
+          ///////////////////////////
+          //  return this.borrowAllowed(); 
+        // })
+        // .then((allowed) => {
+        //   if (!allowed.allowed) {
+        //     this.isBorrowAllowed = false; // if not allowed, sets internal variable to false
+        //     return this.$middleware.getMsjErrorCodeComptroller(
+        //       allowed.errorCode._hex
+        //     );
+        //   }
+        //   this.isBorrowAllowed = true;
+        // }); ///////////////////////////
 
         // await this.data.market.updatedBorrowBy(this.account)
         // .then((borrowBy) => {
@@ -360,7 +373,7 @@ export default {
         this.maxAmount = true;}
     },
     maxAmount() {
-      if (this.maxAmount) this.amount = this.oldMaxBorrowAllowed;
+      if (this.maxAmount) this.amount = this.oldMaxBorrowAllowed.toFixed(18);
       if (!this.maxAmount && this.amount === this.oldMaxBorrowAllowed) this.amount = null;
     },
   },

--- a/src/components/dialog/borrow/BorrowSuccess.vue
+++ b/src/components/dialog/borrow/BorrowSuccess.vue
@@ -115,7 +115,7 @@ export default {
     this.data.market.tokenBalance
       .then((balance) => {
         this.tokenBalance = balance;
-        console.log("success! balance",this.tokenBalance);
+        console.log("success! balance",this.tokenBalance, " account: ", this.account);
         return this.$middleware.getAccountLiquidity(this.account);
         // return this.$rbank.controller.getAccountLiquidity(this.account);
       })

--- a/src/components/dialog/borrow/BorrowSuccess.vue
+++ b/src/components/dialog/borrow/BorrowSuccess.vue
@@ -22,7 +22,7 @@
           <h3>borrow balance:</h3>
         </v-col>
         <v-col cols="3">
-          <h1 class="text-center">{{ borrowBy | formatToken(data.token.decimals) }}</h1>
+          <h1 class="text-center">{{ borrowBy | formatToken(data.token.decimals) | shortenDecimals}}</h1>
         </v-col>
         <v-col cols="2">
           <span class="itemInfo">{{ data.token.symbol }}</span>
@@ -49,7 +49,7 @@
           <h3>borrow limit:</h3>
         </v-col>
         <v-col cols="3">
-          <h1 class="text-center">{{ maxBorrowAllowed | formatToken(data.token.decimals) }}</h1>
+          <h1 class="text-center">{{ maxBorrowAllowed | formatToken(data.token.decimals) | shortenDecimals}}</h1>
         </v-col>
         <v-col cols="2">
           <span class="itemInfo">{{ data.token.symbol }}</span>

--- a/src/middleware/market.js
+++ b/src/middleware/market.js
@@ -177,7 +177,11 @@ export default class Market {
 
   getAmountDecimals(amount, isCtoken = false) {
     //add decimals token
+    console.log("market.js GetAmountDecimals");
+    console.log("amountDecimals: amount", amount);
     amount = amount * Math.pow(10, (!isCtoken) ? decimals[this.token.symbol] : decimals[this.symbol]);
+    console.log("amountDecimals: amount after", amount);
+    console.log("amountDecimals: ethers.BigNumber.from(amount.toString())", ethers.BigNumber.from(amount.toString()));
     return ethers.BigNumber.from(amount.toString());
   }
 
@@ -292,16 +296,20 @@ export default class Market {
      * @dev to be used in borrow modal
      * @param amount of underlying to be borrowed
      * @param {address} account the address of the account
-     * @return 0 if allowed, numerical error otherwise
+     * @return {response, code} response: (bool) if allowed or not, code: numerical error otherwise
      */
   async borrowAllowed(amount, account) {
     amount = this.getAmountDecimals(amount);
-    // console.log("market.js borrowAllowed");
+    console.log("market.js borrowAllowed");
     let contract = this.factoryContract.getContractByNameAndAbiName(constants.Unitroller, constants.Comptroller);
     // console.log("market.js borrowAllowed contract", contract);
-    let isAllowed = await contract.callStatic.borrowAllowed(this.instanceAddress, account, amount);
+    // let isAllowed = await contract.callStatic.borrowAllowed(this.instanceAddress, account, amount);
     // console.log("market.js borrowAllowed allowed?", isAllowed);
-    return isAllowed;
+    // return isAllowed;
+    console.log("market.js borrowAllowed contract", contract);
+    const response=  await contract.callStatic.borrowAllowed(this.instanceAddress, account, amount.toString());
+    console.log("market.js borrowAllowed? response",response);
+    return { "allowed": response == 0, "errorCode": response };
   }
 
   /** TODO

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -26,10 +26,10 @@ export default class Middleware {
    */
 
   async getAccountLiquidity(account) {
-    console.log("getAccountLiquidity ",account);
+    // console.log("getAccountLiquidity ",account);
     const factoryContractInstance = new factoryContract();
     let contract = factoryContractInstance.getContractByNameAndAbiName(constants.Unitroller, constants.Comptroller);
-    console.log("getAccountLiquidity contract",contract);
+    // console.log("getAccountLiquidity contract",contract);
     const [ err, accountLiquidityInExcess, accountShortfall ] = await contract.getAccountLiquidity(account);
     console.log("getAccountLiquidity accountLiquidity",accountLiquidityInExcess);
     return {

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -26,9 +26,12 @@ export default class Middleware {
    */
 
   async getAccountLiquidity(account) {
+    console.log("getAccountLiquidity ",account);
     const factoryContractInstance = new factoryContract();
     let contract = factoryContractInstance.getContractByNameAndAbiName(constants.Unitroller, constants.Comptroller);
-    const [ err, accountLiquidityInExcess, accountShortfall ] = await contract.getAccountLiquidity(account)
+    console.log("getAccountLiquidity contract",contract);
+    const [ err, accountLiquidityInExcess, accountShortfall ] = await contract.getAccountLiquidity(account);
+    console.log("getAccountLiquidity accountLiquidity",accountLiquidityInExcess);
     return {
       err,
       accountLiquidityInExcess,


### PR DESCRIPTION
* getMaxBorrowAllowed() was moved from BorrowInput.vue to market.js
* Added BorrowAllow() validation to borrow() call on BorrowInput.vue
* Rearranged values in BorrowInput modal, to match the same order as shown in RepayInput modal
* Bugfix: now when using MAX button it will no longer pre-input a number with more than 18 decimals
* Added several console.logs to help with debugging
* Added internal variable `this.isBorrowAllowed` that could be used to let user know that the inputted value would fail to borrow() - disabled in getValues() so as to not call the contract on every update.
-------------------------------------------