### PR TITLE
fix and unifying use of getMaxBorrowAllowed()

### DIFF
--- a/src/components/dialog/borrow/BorrowSuccess.vue
+++ b/src/components/dialog/borrow/BorrowSuccess.vue
@@ -97,16 +97,6 @@ export default {
     closeDialog() {
       this.$emit('closeDialog');
     },
-    // getMaxBorrowAllowed() {
-    //   // source: https://medium.com/compound-finance/borrowing-assets-from-compound-quick-start-guide-f5e69af4b8f4
-    //   const res = this.price > 0 ? (this.liquidity/1e18) / (this.price/1e18) : -1;
-    //   return res;
-    // },
-    //////// Original code ///////////////
-    // getMaxAllowed(liquidity, cash) {
-    //   const allowed = this.price > 0 ? Math.floor(liquidity / (this.price * 2)) : 0;
-    //   return allowed >= cash ? cash : allowed;
-    // },
   },
   components: {
     TransactionHash,

--- a/src/components/dialog/borrow/BorrowSuccess.vue
+++ b/src/components/dialog/borrow/BorrowSuccess.vue
@@ -97,11 +97,11 @@ export default {
     closeDialog() {
       this.$emit('closeDialog');
     },
-    getMaxBorrowAllowed() {
-      // source: https://medium.com/compound-finance/borrowing-assets-from-compound-quick-start-guide-f5e69af4b8f4
-      const res = this.price > 0 ? (this.liquidity/1e18) / (this.price/1e18) : -1;
-      return res;
-    },
+    // getMaxBorrowAllowed() {
+    //   // source: https://medium.com/compound-finance/borrowing-assets-from-compound-quick-start-guide-f5e69af4b8f4
+    //   const res = this.price > 0 ? (this.liquidity/1e18) / (this.price/1e18) : -1;
+    //   return res;
+    // },
     //////// Original code ///////////////
     // getMaxAllowed(liquidity, cash) {
     //   const allowed = this.price > 0 ? Math.floor(liquidity / (this.price * 2)) : 0;
@@ -140,7 +140,10 @@ export default {
       .then((borrowBy) => {
         this.borrowBy = Number(borrowBy);
         console.log("success! borrowby",this.borrowBy);
-        this.maxBorrowAllowed = this.getMaxBorrowAllowed();
+        return this.data.market.getMaxBorrowAllowed(this.account);
+      })
+      .then((maxBorrowAllowed) =>{
+        this.maxBorrowAllowed = maxBorrowAllowed;
       });
   },
 };

--- a/src/components/dialog/repay/RepayInput.vue
+++ b/src/components/dialog/repay/RepayInput.vue
@@ -205,10 +205,6 @@ export default {
       return (value / (10 ** this.data.token.decimals))
         .toFixed(this.data.token.decimals);
     },
-    // getMaxBorrowAllowed(liquidity, cash) {
-    //   const allowed = this.price > 0 ? Math.floor(liquidity / (this.price * 2)) : 0;
-    //   return allowed >= cash ? cash : allowed;
-    // },
     getValues() {
       console.log("RepayBorrow: getValues");
       let oldLiquidity;

--- a/src/components/dialog/repay/RepayInput.vue
+++ b/src/components/dialog/repay/RepayInput.vue
@@ -205,10 +205,10 @@ export default {
       return (value / (10 ** this.data.token.decimals))
         .toFixed(this.data.token.decimals);
     },
-    getMaxBorrowAllowed(liquidity, cash) {
-      const allowed = this.price > 0 ? Math.floor(liquidity / (this.price * 2)) : 0;
-      return allowed >= cash ? cash : allowed;
-    },
+    // getMaxBorrowAllowed(liquidity, cash) {
+    //   const allowed = this.price > 0 ? Math.floor(liquidity / (this.price * 2)) : 0;
+    //   return allowed >= cash ? cash : allowed;
+    // },
     getValues() {
       console.log("RepayBorrow: getValues");
       let oldLiquidity;
@@ -315,10 +315,10 @@ export default {
       .then((tokenBalance) => {
         this.tokenBalance = tokenBalance;
         this.supplyValue = tokenBalance;
-        this.maxBorrowAllowed = this.getMaxBorrowAllowed(
-          this.liquidity,
-          this.cash
-        );
+        return this.data.market.getMaxBorrowAllowed(this.account);
+      })
+      .then((maxBorrowAllowed) =>{
+        this.maxBorrowAllowed = maxBorrowAllowed;
         console.log("Repay: this.tokenBalance", this.tokenBalance);
         console.log("Repay: this.maxBorrowAllowed", this.maxBorrowAllowed);
         return this.getAccountHealth(this.account);

--- a/src/components/dialog/supply/SupplyInput.vue
+++ b/src/components/dialog/supply/SupplyInput.vue
@@ -225,11 +225,11 @@ export default {
         this.data.token.decimals
       );
     },
-    getMaxBorrowAllowed(liquidity, cash) {
-      const allowed =
-        this.price > 0 ? Math.floor(liquidity / (this.price * 2)) : 0;
-      return allowed >= cash ? cash : allowed;
-    },
+    // getMaxBorrowAllowed(liquidity, cash) {
+    //   const allowed =
+    //     this.price > 0 ? Math.floor(liquidity / (this.price * 2)) : 0;
+    //   return allowed >= cash ? cash : allowed;
+    // },
     async getValues() {
       let oldLiquidity;
       let oldCash;
@@ -310,10 +310,10 @@ export default {
       .then((tokenBalance) => {
         this.tokenBalance = tokenBalance;
         this.supplyOf = tokenBalance;
-        this.maxBorrowAllowed = this.getMaxBorrowAllowed(
-          this.liquidity,
-          this.cash
-        );
+        return this.data.market.getMaxBorrowAllowed(this.account);
+      })
+      .then((maxBorrowAllowed) =>{
+        this.maxBorrowAllowed = maxBorrowAllowed;
         const internalAddressOfToken = this.data.market.token?.internalAddress;
         return internalAddressOfToken
           ? this.$middleware.getWalletAccountBalance(

--- a/src/components/dialog/supply/SupplyInput.vue
+++ b/src/components/dialog/supply/SupplyInput.vue
@@ -225,11 +225,6 @@ export default {
         this.data.token.decimals
       );
     },
-    // getMaxBorrowAllowed(liquidity, cash) {
-    //   const allowed =
-    //     this.price > 0 ? Math.floor(liquidity / (this.price * 2)) : 0;
-    //   return allowed >= cash ? cash : allowed;
-    // },
     async getValues() {
       let oldLiquidity;
       let oldCash;

--- a/src/components/dialog/withdraw/WithdrawInput.vue
+++ b/src/components/dialog/withdraw/WithdrawInput.vue
@@ -276,11 +276,11 @@ export default {
       // return this.asDouble(allowed);
       return allowed;
     },
-    getMaxBorrowAllowed(liquidity, cash) {
-      const allowed =
-        this.price > 0 ? Math.floor(liquidity / (this.price * 2)) : 0;
-      return allowed >= cash ? cash : allowed;
-    },
+    // getMaxBorrowAllowed(liquidity, cash) {
+    //   const allowed =
+    //     this.price > 0 ? Math.floor(liquidity / (this.price * 2)) : 0;
+    //   return allowed >= cash ? cash : allowed;
+    // },
     async getValues() {
       this.supplyBalanceInfo = Number(this.amount);
       return;
@@ -413,10 +413,10 @@ export default {
           this.supplyOf,
           this.cash
         );
-        this.maxBorrowAllowed = this.getMaxBorrowAllowed(
-          this.liquidity,
-          this.cash
-        );
+        return this.data.market.getMaxBorrowAllowed(this.account);
+        })
+      .then((maxBorrowAllowed) =>{
+        this.maxBorrowAllowed = maxBorrowAllowed;
       });
   },
 };

--- a/src/components/dialog/withdraw/WithdrawInput.vue
+++ b/src/components/dialog/withdraw/WithdrawInput.vue
@@ -276,11 +276,6 @@ export default {
       // return this.asDouble(allowed);
       return allowed;
     },
-    // getMaxBorrowAllowed(liquidity, cash) {
-    //   const allowed =
-    //     this.price > 0 ? Math.floor(liquidity / (this.price * 2)) : 0;
-    //   return allowed >= cash ? cash : allowed;
-    // },
     async getValues() {
       this.supplyBalanceInfo = Number(this.amount);
       return;

--- a/src/middleware/market.js
+++ b/src/middleware/market.js
@@ -306,22 +306,23 @@ export default class Market {
 
   /**
    * getMaxBorrowAllowed Calculates max borrow allowance for this account in this market
+   * @notice this function will may only be used when entered market, otherwise liquidity will be 0
    * @dev to be used in supply, borrow and repay modals
    * @param {address} account the address of the account
    * @return {Number} res the max borrowable amount
    */
-  getMaxBorrowAllowed(account) { // TODO: double check, this might have a bug: under-calculating max
-    // source: https://medium.com/compound-finance/borrowing-assets-from-compound-quick-start-guide-f5e69af4b8f4
-    // res = max(res,0)
+  async getMaxBorrowAllowed(account) {
     let mid = new Middleware();
     let price;
+    let rbtcPrice = await this.getValueMoc();
+    rbtcPrice = rbtcPrice / 1e18 ;
     return this.price
       .then((pri) => {
         price = pri;
         return mid.getAccountLiquidity(account)
       })
-      .then(({err, accountLiquidityInExcess,accountShortfall}) => {
-        const res = price > 0 ? (accountLiquidityInExcess/1e18) / (price/1e18) : 0;
+      .then(({err, accountLiquidityInExcess, accountShortfall}) => {
+        const res = price > 0 ? rbtcPrice * (accountLiquidityInExcess/1e18) / (price/1e18) : 0;
         return res;
       })
   }


### PR DESCRIPTION
* commented out the different versions of getMaxBorrowAllowed, so as to start using the one in market.js
* FIX to getMaxBorrowAllowed(). It was not taking into account that the protocol internally uses rBTC price as 1. **It will now properly calculate the borrow allowance limit.**

--------------------------------------
`NOTICE` users should never borrow close to their borrow allowance limit, or else they're running the risk of being automatically liquidated upon the next block, for running out of collateral.