### PR TITLE
Fix decimals formatting

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,6 @@
 VUE_APP_NETWORK_ID=31
 VUE_APP_WS_PROVIDER=wss://public-node.testnet.rsk.co:433
+VUE_APP_HTTP_PROVIDER=https://public-node.testnet.rsk.co:433
 VUE_APP_RBANK_CONTROLLER=0xda081f6f794bddfb033492d4b0aeb5e7e3e3ce98
 NODE_ENV=test
 BASE_URL=

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@riflending/riflending-js": "../rlending-js",
     "@rsksmart/rbank": "^1.0.1",
     "core-js": "^3.6.4",
-    "decimal.js": "3.0.0",
+    "decimal.js-light": "^2.5.1",
     "ethers": "^5.0.23",
     "lodash": "^4.17.15",
     "register-service-worker": "^1.7.1",

--- a/src/components/dialog/borrow/BorrowInput.vue
+++ b/src/components/dialog/borrow/BorrowInput.vue
@@ -26,7 +26,7 @@
               <v-col cols="7" class="d-flex justify-center">
                 <v-tooltip top>
                   <template v-slot:activator="{ on, attrs }">
-                    <h1 v-bind="attrs" v-on="on">{{ cash | formatToken(data.token.decimals) | shortenDecimals }}</h1>
+                    <h1 v-bind="attrs" v-on="on">{{ cash | formatToken(data.token.decimals) }}</h1>
                   </template>
                   <span>{{ cash | formatToken(data.token.decimals) }}</span>
                 </v-tooltip>
@@ -47,7 +47,7 @@
           <v-col cols="4">
             <v-row class="ma-0 d-flex align-center">
               <v-col cols="7" class="d-flex justify-center">
-                <h1>{{ borrowBy | formatToken(data.token.decimals) | shortenDecimals}}</h1>
+                <h1>{{ borrowBy | formatToken(data.token.decimals)}}</h1>
               </v-col>
               <!-- <v-col cols="5" class="itemInfo">
                 <span class="text-center" v-if="borrowBalanceInfo">
@@ -69,7 +69,7 @@
           <v-col cols="4">
             <v-row class="ma-0 d-flex align-center">
               <v-col cols="7" class="d-flex justify-center">
-                <h1>{{ maxBorrowAllowed | formatToken(data.token.decimals) | shortenDecimals}}</h1>
+                <h1>{{ maxBorrowAllowed | formatToken(data.token.decimals)}}</h1>
               </v-col>
               <v-col cols="5" class="itemInfo">
                 <!-- <span class="text-center" v-if="borrowLimitInfo">

--- a/src/components/dialog/borrow/BorrowSuccess.vue
+++ b/src/components/dialog/borrow/BorrowSuccess.vue
@@ -22,7 +22,7 @@
           <h3>borrow balance:</h3>
         </v-col>
         <v-col cols="3">
-          <h1 class="text-center">{{ borrowBy | formatToken(data.token.decimals) | shortenDecimals}}</h1>
+          <h1 class="text-center">{{ borrowBy | formatToken(data.token.decimals)}}</h1>
         </v-col>
         <v-col cols="2">
           <span class="itemInfo">{{ data.token.symbol }}</span>
@@ -49,7 +49,7 @@
           <h3>borrow limit:</h3>
         </v-col>
         <v-col cols="3">
-          <h1 class="text-center">{{ maxBorrowAllowed | formatToken(data.token.decimals) | shortenDecimals}}</h1>
+          <h1 class="text-center">{{ maxBorrowAllowed | formatToken(data.token.decimals)}}</h1>
         </v-col>
         <v-col cols="2">
           <span class="itemInfo">{{ data.token.symbol }}</span>

--- a/src/components/dialog/repay/RepayInput.vue
+++ b/src/components/dialog/repay/RepayInput.vue
@@ -37,7 +37,7 @@
           <v-col cols="4">
             <v-row class="ma-0 d-flex align-center">
               <v-col cols="7" class="d-flex justify-center">
-                <h1>{{ borrowBy | formatToken(data.token.decimals) | shortenDecimals }}</h1>
+                <h1>{{ borrowBy | formatToken(data.token.decimals) }}</h1>
               </v-col>
               <v-col cols="5" class="itemInfo">
                 <!--<span class="text-center" v-if="borrowBalanceInfo">-->
@@ -59,7 +59,7 @@
           <v-col cols="4">
             <v-row class="ma-0 d-flex align-center">
               <v-col cols="7" class="d-flex justify-center">
-                <h1>{{ maxBorrowAllowed | formatToken(data.token.decimals)  | shortenDecimals }}</h1>
+                <h1>{{ maxBorrowAllowed | formatToken(data.token.decimals) }}</h1>
               </v-col>
               <v-col cols="5" class="itemInfo">
                 <!--<span class="text-center" v-if="borrowLimitInfo">-->

--- a/src/components/dialog/repay/RepaySuccess.vue
+++ b/src/components/dialog/repay/RepaySuccess.vue
@@ -33,7 +33,7 @@
           <h3>borrow balance:</h3>
         </v-col>
         <v-col cols="3">
-          <h1 class="text-center">{{ borrowBy | formatToken(data.token.decimals) | shortenDecimals }}</h1>
+          <h1 class="text-center">{{ borrowBy | formatToken(data.token.decimals) }}</h1>
         </v-col>
         <v-col cols="2">
           <span class="itemInfo">{{ data.token.symbol }}</span>

--- a/src/components/dialog/supply/SupplyInput.vue
+++ b/src/components/dialog/supply/SupplyInput.vue
@@ -58,7 +58,7 @@
             <v-row class="ma-0 d-flex align-center">
               <v-col cols="7" class="d-flex justify-center">
                 <h1 :title="[`Balance ${tokenBalance} ${data.token.symbol}`]">
-                  {{ +tokenBalance | formatNumber() }}
+                  {{ tokenBalance | formatNumber }}
                 </h1>
               </v-col>
               <!-- <v-col cols="5" class="itemInfo d-flex justify-center">
@@ -85,7 +85,6 @@
                   {{
                     maxBorrowAllowed
                       | formatToken(data.token.decimals)
-                      | shortenDecimals
                   }}
                 </h1>
               </v-col>

--- a/src/components/dialog/supply/SupplySuccess.vue
+++ b/src/components/dialog/supply/SupplySuccess.vue
@@ -25,7 +25,7 @@
           <v-row class="ma-0 d-flex align-center">
             <v-col cols="7" class="d-flex justify-center">
               <h1>
-                {{ cash | formatToken(data.token.decimals) | shortenDecimals }}
+                {{ cash | formatToken(data.token.decimals) }}
               </h1>
             </v-col>
             <v-col cols="5" class="itemInfo">
@@ -48,7 +48,7 @@
         <v-col cols="4">
           <v-row class="ma-0 d-flex align-center">
             <v-col cols="7" class="d-flex justify-center">
-              <h1>{{ supplyOf | shortenDecimals }}</h1>
+              <h1>{{ supplyOf | formatNumber }}</h1>
             </v-col>
             <v-col cols="5" class="itemInfo">
               <!-- <span v-if="data.supplyBalanceInfo">
@@ -70,7 +70,7 @@
         <v-col cols="4">
           <v-row class="ma-0 d-flex align-center">
             <v-col cols="7" class="d-flex justify-center">
-              <h1>{{ maxBorrowAllowed | formatToken(data.token.decimals)| shortenDecimals}}</h1>
+              <h1>{{ maxBorrowAllowed | formatToken(data.token.decimals) }}</h1>
             </v-col>
             <v-col cols="5" class="itemInfo">
               <span v-if="data.borrowLimitInfo">

--- a/src/components/dialog/withdraw/WithdrawInput.vue
+++ b/src/components/dialog/withdraw/WithdrawInput.vue
@@ -48,7 +48,6 @@
                       {{
                         cash
                           | formatToken(data.token.decimals)
-                          | shortenDecimals
                       }}
                     </h1>
                   </template>
@@ -72,7 +71,7 @@
             <v-row class="ma-0 d-flex align-center">
               <v-col cols="7" class="d-flex justify-center">
                 <h1 :title="[`Balance ${tokenBalance} ${data.token.symbol}`]">
-                  {{ +tokenBalance | formatNumber() }}
+                  {{ tokenBalance | formatNumber }}
                 </h1>
               </v-col>
               <v-col cols="5" class="itemInfo">
@@ -99,7 +98,6 @@
                   {{
                     maxBorrowAllowed
                       | formatToken(data.token.decimals)
-                      | shortenDecimals
                   }}
                 </h1>
               </v-col>

--- a/src/components/dialog/withdraw/WithdrawSuccess.vue
+++ b/src/components/dialog/withdraw/WithdrawSuccess.vue
@@ -38,7 +38,7 @@
         </v-col>
         <v-col cols="3">
           <h1 class="text-center">
-            {{ supplyOf | shortenDecimals }}
+            {{ supplyOf | formatNumber }}
           </h1>
         </v-col>
         <v-col cols="2">
@@ -56,7 +56,6 @@
             {{
               maxBorrowAllowed
                 | formatToken(data.token.decimals)
-                | shortenDecimals
             }}
           </h1>
         </v-col>

--- a/src/components/supply/SupplyItem.vue
+++ b/src/components/supply/SupplyItem.vue
@@ -28,7 +28,7 @@
           <v-row class="ma-0">
             <v-col cols="9" class="pa-0 d-flex align-center">
               <v-list-item-subtitle class="item">
-                {{ tokenBalance }}
+                {{ tokenBalance | formatNumber }}
                 <!-- {{ tokenBalance | formatToken(token.decimals) }} -->
               </v-list-item-subtitle>
             </v-col>

--- a/src/components/supply/SupplyList.vue
+++ b/src/components/supply/SupplyList.vue
@@ -16,7 +16,7 @@
           </v-col>
           <v-col cols="4">
             <v-list-item-subtitle class="listTitle"
-              >Wallet</v-list-item-subtitle
+              >Supplied</v-list-item-subtitle
             >
           </v-col>
         </v-row>

--- a/src/filters/index.js
+++ b/src/filters/index.js
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import Decimal from 'decimal.js';
+import { Decimal } from 'decimal.js-light';
 
 Vue.filter('formatPrice', (value) => {
   const val = (value / 1).toFixed(2)
@@ -8,22 +8,16 @@ Vue.filter('formatPrice', (value) => {
     .replace(/\B(?=(\d{3})+(?!\d))/g, ',')}`;
 });
 
-Vue.filter('formatToken', (value, decimals) => {
+function toSD(value, digits = 6) {
+  Decimal.set({ rounding: Decimal.ROUND_UP, toExpNeg: -18, toExpPos: 36 });
+  return new Decimal(Number(value).toFixed(digits)).toSignificantDigits(digits);
+}
+
+Vue.filter('formatToken', (value, decimals, digits = 6) => {
   const val = (value / (10 ** decimals)).toFixed(decimals);
-  const int = decimals > 0 ? val.substring(0, val.indexOf('.')) : val;
-  const decimalZeros = val.substring(val.indexOf('.') + 1, val.length);
-  const decimal = Number(decimalZeros) === 0 ? Number(decimalZeros)
-    .toString() : decimalZeros.replace(/\.?0+$/, '');
-  return decimals > 0 ? `${int
-    .replace(/\B(?=(\d{3})+(?!\d))/g, ',')}.${decimal}` : `${int
-    .replace(/\B(?=(\d{3})+(?!\d))/g, ',')}`;
+  return toSD(val, digits);
 });
 
-Vue.filter('shortenDecimals', (value) => {
-  const d = new Decimal(value)
-  return d.toSignificantDigits(6)
-});
-
-Vue.filter('formatNumber', (value, decimals = 6) => value.toFixed(decimals));
+Vue.filter('formatNumber', toSD);
 
 Vue.filter('formatPercentage', (value) => `${Number(value).toFixed(2)} %`);

--- a/src/main.js
+++ b/src/main.js
@@ -17,11 +17,11 @@ Vue.config.productionTip = false;
 // eslint-disable-next-line no-multi-assign
 Vue.prototype.$rbank = Vue.rbank = new Rbank(
   {
-    [process.env.VUE_APP_NETWORK_ID]: process.env.VUE_APP_WS_PROVIDER,
+    [process.env.VUE_APP_NETWORK_ID]: process.env.VUE_APP_HTTP_PROVIDER,
   },
 );
 // eslint-disable-next-line no-multi-assign
-Vue.prototype.$rlending = Vue.rlending = new Rlending(process.env.VUE_APP_WS_PROVIDER);
+Vue.prototype.$rlending = Vue.rlending = new Rlending(process.env.VUE_APP_HTTP_PROVIDER);
 // eslint-disable-next-line no-multi-assign
 Vue.prototype.$middleware = Vue.middleware = new Middleware();
 new Vue({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3858,10 +3858,10 @@ decamelize@^1.1.2, decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
-decimal.js@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-3.0.0.tgz#ef20537863357492a29393c5ba21108e4af22d2b"
-  integrity sha1-7yBTeGM1dJKik5PFuiEQjkryLSs=
+decimal.js-light@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/decimal.js-light/-/decimal.js-light-2.5.1.tgz#134fd32508f19e208f4fb2f8dac0d2626a867934"
+  integrity sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==
 
 decode-uri-component@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Remove shortenDecimals vue filter
We where using an older version of the decimal.js, instead of bumping it to the 10, decided to use the light version
Change wss for https as we are getting a lot of errors for this
Use formatNumber to show token balances that have already been converted to decimals and need to be formated to Significant Digits
Use formatToken to convert to decimal precision, and then format it to significant digits