### PR TITLE
fix negative number shown in modal

### DIFF
--- a/src/components/dialog/borrow/BorrowInput.vue
+++ b/src/components/dialog/borrow/BorrowInput.vue
@@ -342,7 +342,7 @@ export default {
         this.maxAmount = true;}
     },
     maxAmount() {
-      if (this.maxAmount) this.amount = this.oldMaxBorrowAllowed;
+      if (this.maxAmount) this.amount = Math.min(this.oldMaxBorrowAllowed,this.cash/1e18);
       if (!this.maxAmount && this.amount === this.oldMaxBorrowAllowed) this.amount = null;
     },
   },


### PR DESCRIPTION
* When using MAX button in BorrowInput modal, it will now calculate the minimum value between the contract's available supply and the max borrow allowed