### PR TITLE
Fix borrow limit (maxBorrowAllowed)

### DIFF
--- a/src/components/dialog/borrow/BorrowInput.vue
+++ b/src/components/dialog/borrow/BorrowInput.vue
@@ -261,7 +261,9 @@ export default {
         return this.data.market.getMaxBorrowAllowed(this.account)
       })
       .then((maxBorrowAllowed) => {
+        console.log('BorrowInput create() maxborrowalloweddddd', maxBorrowAllowed)
         this.maxBorrowAllowed = maxBorrowAllowed
+        console.log('BorrowInput create() maxborrowalloweddddd', this.maxBorrowAllowed)
         this.oldMaxBorrowAllowed = this.asDouble(maxBorrowAllowed)
         this.borrowAllowance = maxBorrowAllowed
         this.borrowBalanceInfo = Number(this.contractAmount)
@@ -410,6 +412,7 @@ export default {
           return this.data.market.getMaxBorrowAllowed(this.account)
         })
         .then((maxBorrowAllowed) => {
+          console.log('BorrowInput updated() maxborrowallowed', maxBorrowAllowed)
           this.maxBorrowAllowed = maxBorrowAllowed
           this.borrowAllowance = maxBorrowAllowed
           this.borrowBalanceInfo = Number(this.contractAmount)

--- a/src/components/dialog/borrow/BorrowInput.vue
+++ b/src/components/dialog/borrow/BorrowInput.vue
@@ -86,7 +86,7 @@
           <v-col cols="4">
             <v-row class="ma-0 d-flex align-center">
               <v-col cols="7" class="d-flex justify-center">
-                <h1>{{ maxBorrowAllowed | formatToken(data.token.decimals) }}</h1>
+                <h1>{{ maxBorrowAllowed | formatNumber }}</h1>
               </v-col>
             </v-row>
           </v-col>
@@ -261,9 +261,7 @@ export default {
         return this.data.market.getMaxBorrowAllowed(this.account)
       })
       .then((maxBorrowAllowed) => {
-        console.log('BorrowInput create() maxborrowalloweddddd', maxBorrowAllowed)
         this.maxBorrowAllowed = maxBorrowAllowed
-        console.log('BorrowInput create() maxborrowalloweddddd', this.maxBorrowAllowed)
         this.oldMaxBorrowAllowed = this.asDouble(maxBorrowAllowed)
         this.borrowAllowance = maxBorrowAllowed
         this.borrowBalanceInfo = Number(this.contractAmount)
@@ -412,7 +410,6 @@ export default {
           return this.data.market.getMaxBorrowAllowed(this.account)
         })
         .then((maxBorrowAllowed) => {
-          console.log('BorrowInput updated() maxborrowallowed', maxBorrowAllowed)
           this.maxBorrowAllowed = maxBorrowAllowed
           this.borrowAllowance = maxBorrowAllowed
           this.borrowBalanceInfo = Number(this.contractAmount)

--- a/src/components/dialog/repay/RepayInput.vue
+++ b/src/components/dialog/repay/RepayInput.vue
@@ -74,7 +74,7 @@
           <v-col cols="4">
             <v-row class="ma-0 d-flex align-center">
               <v-col cols="7" class="d-flex justify-center">
-                <h1>{{ maxBorrowAllowed | formatToken(data.token.decimals) }}</h1>
+                <h1>{{ maxBorrowAllowed | formatNumber }}</h1>
               </v-col>
             </v-row>
           </v-col>

--- a/src/components/dialog/supply/SupplyInput.vue
+++ b/src/components/dialog/supply/SupplyInput.vue
@@ -75,7 +75,7 @@
             <v-row class="ma-0 d-flex align-center">
               <v-col cols="7" class="d-flex justify-center">
                 <h1>
-                  {{ maxBorrowAllowed | formatToken(data.token.decimals) }}
+                  {{ maxBorrowAllowed | formatNumber }}
                 </h1>
               </v-col>
             </v-row>

--- a/src/components/dialog/withdraw/WithdrawInput.vue
+++ b/src/components/dialog/withdraw/WithdrawInput.vue
@@ -87,7 +87,7 @@
             <v-row class="ma-0 d-flex align-center">
               <v-col cols="7" class="d-flex justify-center">
                 <h1>
-                  {{ maxBorrowAllowed | formatToken(data.token.decimals) }}
+                  {{ maxBorrowAllowed | formatNumber }}
                 </h1>
               </v-col>
             </v-row>

--- a/src/middleware/market.js
+++ b/src/middleware/market.js
@@ -358,7 +358,8 @@ export default class Market {
    */
   async getMaxBorrowAllowed(account) {
     const middleware = new Middleware() // maybe not necesary to load a whole Middleware here
-    const price = await this.price // current market price
+    //set price
+    const price = await this.getPrice() // current market price
     let rbtcPrice = await this.getValueMoc() // rbtc price
     rbtcPrice /= 1e18 // in usd
     const { accountLiquidityInExcess } = await middleware.getAccountLiquidity(account)


### PR DESCRIPTION
* Fixed a but from the previous rework, maxBorrowAllowed where it miscalculated the underlying price.
* Fixed another bug arose when showing the BorrowLimit number