### PR TITLE
fixing the health factor calculations

### DIFF
--- a/src/components/dialog/repay/RepayInput.vue
+++ b/src/components/dialog/repay/RepayInput.vue
@@ -237,7 +237,7 @@ export default {
       })
       .then((maxBorrowAllowed) => {
         this.maxBorrowAllowed = maxBorrowAllowed
-        return this.getAccountHealth(this.account)
+        return this.$middleware.getAccountHealth(this.account)
       })
       // sets health & gets collateralFactor
       .then((health) => {
@@ -294,16 +294,10 @@ export default {
         })
     },
 
-    getAccountHealth() {
-      // TODO: SEND TO MIDDLEWARE
-      if (this.supplyValue == 0 || this.borrowed == 0) return 0
-      const borrowValue = this.borrowed * this.mantissa
-      return (this.supplyValue * this.mantissa) / borrowValue
-    },
-
     asDouble(value) {
       return (value / 10 ** this.data.token.decimals).toFixed(this.data.token.decimals)
     },
+
     getValues() {
       console.log('RepayBorrow: getValues')
       // TODO check oldLiquidity usage here

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -64,7 +64,6 @@ export default class Middleware {
    *          account liquidity in excess of collateral requirements,
    *          account shortfall below collateral requirements)
    */
-
   async getAccountLiquidity(account) {
     const factoryContractInstance = new factoryContract()
     const contract = factoryContractInstance.getContractByNameAndAbiName(
@@ -159,13 +158,91 @@ export default class Middleware {
     return liqFactor
   }
 
+  /**
+   * getAccountHealth calculates the account health factor
+   * @dev returns percentage value between 0 and 1
+   * @param account Address of the account to snapshot
+   * @return 1 - (SUM_market borrowValue / SUM_market(supplyValue * colFact) )
+   */
   async getAccountHealth(account) {
-    const { borrowValue, supplyValue } = await this.getTotals(account)
-    if (supplyValue == 0 || borrowValue == 0) return 1
-    //returns 1 minus the division of borrow by supply. Supply is div 2, because of the collateral factor
-    return 1 - borrowValue / (supplyValue / 2)
-    // TODO: uncomment the line below to remove hardcoded div 2 value
-    //const colFact = this.getCollateralFactor()
-    // return 1 - borrowValue / (supplyValue * colFact)
+    const markets = await this.getMarkets(account)
+    console.log('accountHealth markets', markets)
+    const marketsPromises = markets.map(
+      (market) =>
+        new Promise((resolve, reject) => {
+          ;(async () => {
+            try {
+              console.log('accountHealth promise', market.token.symbol)
+              const borrowBalanceCurrent = await market.borrowBalanceCurrentFormatted(account)
+              const borrowBalanceCurrentBN = new BigNumber(borrowBalanceCurrent)
+              const marketPriceFromOracleBN = await market.getPriceInDecimals()
+              const marketPriceBN = marketPriceFromOracleBN || new BigNumber(0)
+              console.log('accountHealth marketPriceBN', market.token.symbol, marketPriceBN)
+
+              const tokenBalance = await market.getBalanceOfUnderlying(account)
+              const tokenBalanceBN = new BigNumber(tokenBalance)
+              console.log('accountHealth tokenBalanceBN', market.token.symbol, tokenBalanceBN)
+              const colFact = market.collateralFactorMantissa
+              console.log('accountHealth colFact', market.token.symbol, colFact)
+              const colNum = Number(colFact)
+              // console.log("accountHealth market decimals", market.token.decimals)
+              console.log('accountHealth colNum', colNum)
+              console.log('accountHealth colNum/1e18', colNum / market.factor)
+
+              const colStr = colNum / market.factor.toString()
+              console.log('accountHealth colStr', colStr)
+
+              const colFactBN = new BigNumber(colStr)
+              console.log('accountHealth colFactBN', market.token.symbol, Number(colFactBN))
+
+              const borrowValue = borrowBalanceCurrentBN.multipliedBy(marketPriceBN)
+              console.log('accountHealth borrowValue', market.token.symbol, Number(borrowValue))
+              const supplyValue = tokenBalanceBN.multipliedBy(marketPriceBN)
+              console.log('accountHealth supplyValue', market.token.symbol, Number(supplyValue))
+
+              const supByFactor = supplyValue.multipliedBy(colFactBN)
+              console.log('accountHealth supByFactor', market.token.symbol, Number(supByFactor))
+              // const marketHealth = 1 - (borrowValue.dividedBy(supplyValue))
+              resolve({ borrowValue, supByFactor })
+            } catch (err) {
+              reject(err)
+            }
+          })()
+        }),
+    )
+    console.log('accountHealth endedMapping')
+    const totals = await Promise.all(marketsPromises)
+    console.log('accountHealth totals', totals)
+    // return 1 - (SUM borrowValue / SUM(supplyValue * colFact) )
+    let numerator = new BigNumber(0)
+    let denominator = new BigNumber(0)
+    // for(let mkt in totals){
+    //   numerator = numerator.plus(mkt.borrowValue)
+    //   denominator = denominator.plus(mkt.supByFactor)
+    // }
+    for (let i = 0, len = totals.length; i < len; i++) {
+      numerator = numerator.plus(totals[i].borrowValue)
+      denominator = denominator.plus(totals[i].supByFactor)
+    }
+    if (denominator == 0 || numerator == 0) {
+      console.log('AccountHealth returns zero values')
+      return 1
+    }
+    // numerator = numerator.plus(totals[0].borrowValue).plus(totals[1].borrowValue)
+    console.log('accountHealth numerator', numerator, ' div', denominator)
+    console.log('accountHealth 1?', new BigNumber(1))
+    console.log('accountHealth 1-numerator?', new BigNumber(1).minus(numerator))
+    console.log(
+      'accountHealth 1-numerator div denominator?',
+      new BigNumber(1).minus(numerator).div(denominator),
+    )
+    const healtFactor = new BigNumber(1).minus(numerator.div(denominator))
+    console.log('accountHealth health factor', healtFactor)
+    console.log('accountHealth health num/den', numerator.div(denominator))
+    console.log('accountHealth health Number num/den', Number(numerator.div(denominator)))
+
+    console.log('accountHealth health factor Number', Number(healtFactor))
+
+    return Number(healtFactor)
   }
 }

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -209,6 +209,6 @@ export default class Middleware {
 
     if (denominator == 0 || numerator == 0) return 1
 
-    return Number(new BigNumber(1).minus(numerator.div(denominator)))
+    return new BigNumber(1).minus(numerator.div(denominator)).toNumber()
   }
 }

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -133,7 +133,10 @@ export default class Middleware {
   async getAccountHealth(account) {
     const { borrowValue, supplyValue } = await this.getTotals(account)
     if (supplyValue == 0 || borrowValue == 0) return 1
-    //returns 1 minus the division of borrow by supply. Supply is div 2, because of the reserve factor
+    //returns 1 minus the division of borrow by supply. Supply is div 2, because of the collateral factor
     return 1 - borrowValue / (supplyValue / 2)
+    // TODO: uncomment the line below to remove hardcoded div 2 value
+    //const colFact = this.getCollateralFactor()
+    // return 1 - borrowValue / (supplyValue * colFact)
   }
 }

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -131,18 +131,9 @@ export default class Middleware {
   }
 
   async getAccountHealth(account) {
-    // DTI Debt to Income
-    // TODO: fix this function, probably not calculating the right number
-    console.log('getAccountHealth')
-    const liqFactor = await this.getLiquidationFactor()
-    console.log('getAccountHealth liquidateFactor', liqFactor)
-    if (supplyValue == 0 || borrowValue == 0) return 0
     const { borrowValue, supplyValue } = await this.getTotals(account)
-    console.log('getAccountHealth getTotals borrow', borrowValue, ' supply', supplyValue)
-    const val = supplyValue.div(borrowValue * liqFactor)
-    console.log('val', val)
-    const ret = 1 / (1 + Math.exp(-val.toNumber()))
-    console.log('getAccountHealth return', ret)
-    return ret > 1 ? 1 : ret < 0 ? 0 : ret
+    if (supplyValue == 0 || borrowValue == 0) return 1
+    //returns 1 minus the division of borrow by supply. Supply is div 2, because of the reserve factor
+    return 1 - borrowValue / (supplyValue / 2)
   }
 }

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -105,6 +105,7 @@ export default class Middleware {
   }
 
   async getTotals(account) {
+    //TODO: This function shouldn't have so many new BigNumber()
     const markets = await this.getMarkets(account)
     const marketsPromises = markets.map(
       (market) =>
@@ -165,6 +166,8 @@ export default class Middleware {
    * @return 1 - (SUM_market borrowValue / SUM_market(supplyValue * colFact) )
    */
   async getAccountHealth(account) {
+    //TODO: This function shouldn't have so many new BigNumber(), casting to Number and string
+    //      try to unify criteria
     const markets = await this.getMarkets(account)
     const marketsPromises = markets.map(
       (market) =>
@@ -180,15 +183,15 @@ export default class Middleware {
               const tokenBalanceBN = new BigNumber(tokenBalance)
               const colFact = market.collateralFactorMantissa
 
-              const colNum = Number(colFact)
-              const colStr = colNum / market.factor.toString()
-              const colFactBN = new BigNumber(colStr)
+              const colFactNum = Number(colFact)
+              const colFactStr = colFactNum / market.factor.toString()
+              const colFactBN = new BigNumber(colFactStr)
 
               const borrowValue = borrowBalanceCurrentBN.multipliedBy(marketPriceBN)
               const supplyValue = tokenBalanceBN.multipliedBy(marketPriceBN)
 
-              const supByFactor = supplyValue.multipliedBy(colFactBN)
-              resolve({ borrowValue, supByFactor })
+              const supplyByFactor = supplyValue.multipliedBy(colFactBN)
+              resolve({ borrowValue, supplyByFactor })
             } catch (err) {
               reject(err)
             }
@@ -201,7 +204,7 @@ export default class Middleware {
 
     for (let i = 0, len = totals.length; i < len; i++) {
       numerator = numerator.plus(totals[i].borrowValue)
-      denominator = denominator.plus(totals[i].supByFactor)
+      denominator = denominator.plus(totals[i].supplyByFactor)
     }
 
     if (denominator == 0 || numerator == 0) return 1


### PR DESCRIPTION
* Fixes `getHealthFactor` so that it shows a number that corresponds with the equation: `1 - (totalBorrows / (totalSupplied / 2)`
* Removed getHealthFactor from repay modal and used the function declared in Middleware

![image](https://user-images.githubusercontent.com/5059808/104058240-2e7f2a80-51d2-11eb-88eb-8e89af5d799e.png)
