### PR TITLE
fixes getPrice() - calculates proper market prices

### DIFF
--- a/src/middleware/market.js
+++ b/src/middleware/market.js
@@ -1,5 +1,3 @@
-/* eslint-disable prettier/prettier */
-/* eslint-disable no-unreachable */
 import { ethers } from 'ethers'
 import BigNumber from 'bignumber.js'
 import factoryContract from './factoryContract'

--- a/src/middleware/market.js
+++ b/src/middleware/market.js
@@ -1,3 +1,5 @@
+/* eslint-disable prettier/prettier */
+/* eslint-disable no-unreachable */
 import { ethers } from 'ethers'
 import BigNumber from 'bignumber.js'
 import factoryContract from './factoryContract'
@@ -112,12 +114,13 @@ export default class Market {
     // get price of cToken
     const priceToken = await contract.callStatic.getUnderlyingPrice(this.instanceAddress)
     // get price of rbtc
-    const valueOracle = await this.getValueMoc()
-    // price = ( price cToken in rbtc * price of rbtc) /  Oracle precision decimals
-    return new BigNumber(priceToken.toString())
-      .multipliedBy(valueOracle)
-      .div(new BigNumber(1e18))
-      .toNumber()
+    return new BigNumber(priceToken.toString()).toNumber()
+    // const valueOracle = await this.getValueMoc()
+    // // price = ( price cToken in rbtc * price of rbtc) /  Oracle precision decimals
+    // return new BigNumber(priceToken.toString())
+    //   .multipliedBy(valueOracle)
+    //   .div(new BigNumber(1e18))
+    //   .toNumber()
   }
 
   async getUserBalanceOfCtoken() {


### PR DESCRIPTION
Newly deployed prococol uses contracts that return the price in USD. This fixes the getPrice() function so that it doesn't divide by the RBTC price.


![image](https://user-images.githubusercontent.com/5059808/105387974-d9d9a780-5bf4-11eb-9db5-6c33788054b4.png)
