### PR TITLE
Allow the maximum balance to be used on erc20 tokens

### DIFF
--- a/src/components/dialog/liquidate/LiquidateInput.vue
+++ b/src/components/dialog/liquidate/LiquidateInput.vue
@@ -400,13 +400,17 @@ export default {
           )
         : this.$middleware.getWalletAccountBalanceForRBTC(this.account)
       walletBalancePromise.then((balanceOfToken) => {
-        this.$middleware.getGasPrice().then((price) => {
-          // balanceOfToken - (gasPrice * gasLimit)
-          const max = new BigNumber(balanceOfToken).minus(
-            price.multipliedBy(this.data.market.gasLimit),
-          )
-          this.funds = max.isNegative() ? 0 : max.toString()
-        })
+        if (this.data.market.isCRBTC) {
+          this.$middleware.getGasPrice().then((price) => {
+            // balanceOfToken - (gasPrice * gasLimit)
+            const max = new BigNumber(balanceOfToken).minus(
+              price.multipliedBy(this.data.market.gasLimit),
+            )
+            this.funds = max.isNegative() ? 0 : max.toString()
+          })
+        } else {
+          this.funds = new BigNumber(balanceOfToken).toString()
+        }
       })
     },
     getCollateralMarketMaxAssetSelected() {

--- a/src/components/dialog/repay/RepayInput.vue
+++ b/src/components/dialog/repay/RepayInput.vue
@@ -207,13 +207,17 @@ export default {
       ? this.$middleware.getWalletAccountBalance(this.account, this.data.market.token?.address)
       : this.$middleware.getWalletAccountBalanceForRBTC(this.account)
     walletBalancePromise.then((balanceOfToken) => {
-      this.$middleware.getGasPrice().then((price) => {
-        // balanceOfToken - (gasPrice * gasLimit)
-        const max = new BigNumber(balanceOfToken).minus(
-          price.multipliedBy(this.data.market.gasLimit).multipliedBy(2),
-        )
-        this.maxAmountBalanceAllowed = max.isNegative() ? 0 : max.toString()
-      })
+      if (this.data.market.isCRBTC) {
+        this.$middleware.getGasPrice().then((price) => {
+          // balanceOfToken - (gasPrice * gasLimit)
+          const max = new BigNumber(balanceOfToken).minus(
+            price.multipliedBy(this.data.market.gasLimit).multipliedBy(2),
+          )
+          this.maxAmountBalanceAllowed = max.isNegative() ? 0 : max.toString()
+        })
+      } else {
+        this.maxAmountBalanceAllowed = new BigNumber(balanceOfToken).toString()
+      }
     })
   },
   methods: {

--- a/src/components/dialog/supply/SupplyInput.vue
+++ b/src/components/dialog/supply/SupplyInput.vue
@@ -222,13 +222,17 @@ export default {
           : this.$middleware.getWalletAccountBalanceForRBTC(this.account)
       })
       .then((balanceOfToken) => {
-        this.$middleware.getGasPrice().then((price) => {
-          // balanceOfToken - (gasPrice * gasLimit * 2)
-          const max = new BigNumber(balanceOfToken).minus(
-            price.multipliedBy(this.data.market.gasLimit).multipliedBy(2),
-          )
-          this.maxAmountBalanceAllowed = max.isNegative() ? 0 : max.toString()
-        })
+        if (this.data.market.isCRBTC) {
+          this.$middleware.getGasPrice().then((price) => {
+            // balanceOfToken - (gasPrice * gasLimit * 2)
+            const max = new BigNumber(balanceOfToken).minus(
+              price.multipliedBy(this.data.market.gasLimit).multipliedBy(2),
+            )
+            this.maxAmountBalanceAllowed = max.isNegative() ? 0 : max.toString()
+          })
+        } else {
+          this.maxAmountBalanceAllowed = new BigNumber(balanceOfToken).toString()
+        }
       })
   },
   methods: {


### PR DESCRIPTION
In case the market is not btc, use the maximum balance available, only in the section supply, liquidate and repay.